### PR TITLE
ensure that packages is always written with unix paths

### DIFF
--- a/lib/CPAN/Repository/Packages.pm
+++ b/lib/CPAN/Repository/Packages.pm
@@ -81,7 +81,7 @@ sub add_distribution {
 	my $filename = catfile( $self->repository_root, @{$self->authorbase_path_parts}, splitdir( $author_distribution_path ) );
 	my $dist = Dist::Data->new( $filename );
 	for (keys %{$dist->packages}) {
-		$self->set_module($_, $dist->packages->{$_}->{version}, $author_distribution_path);
+		$self->set_module($_, $dist->packages->{$_}->{version}, File::Spec::Unix->catfile(splitdir $author_distribution_path));
 	}
 	return $self;
 }

--- a/t/10-simple.t
+++ b/t/10-simple.t
@@ -8,6 +8,8 @@ use File::Temp qw/ tempfile tempdir /;
 
 use CPAN::Repository;
 
+sub local_path_to_unix { File::Spec->catdir( File::Spec::Unix->splitdir( @_ ) ) }
+
 BEGIN {
 
 	my $tempdir = tempdir;
@@ -53,8 +55,8 @@ BEGIN {
 	}, 'Checking module state of the packages file');
 
 	is_deeply($repo->modules, {
-		'My::Other::Sample' => $tempdir.'/authors/id/F/FA/FAMILYGUY/My-Other-Sample-0.001.tar.gz',
-		'My::Sample::Distribution' => $tempdir.'/authors/id/THIS_IS_SOOO_GOOD/My-Sample-Distribution-0.004.tar.gz'
+		'My::Other::Sample' => local_path_to_unix( $tempdir.'/authors/id/F/FA/FAMILYGUY/My-Other-Sample-0.001.tar.gz' ),
+		'My::Sample::Distribution' => local_path_to_unix( $tempdir.'/authors/id/THIS_IS_SOOO_GOOD/My-Sample-Distribution-0.004.tar.gz' )
 	}, 'Checking module state of the repository');
 	
 	my @packages_lines = grep { $_ !~ /^Last-Updated:/ } map { chomp($_); $_; } $repo->packages->get_file_lines;


### PR DESCRIPTION
Not entirely sure if this makes sense, but it allows the tests to pass on windows.